### PR TITLE
Add base image for nft-market-place (fix ssl problem)

### DIFF
--- a/arion-compose.nix
+++ b/arion-compose.nix
@@ -115,6 +115,7 @@ in {
         [ "${toString ./.}/data/postgres-data:/var/lib/postgresql/data" ];
     };
     nft-marketplace-server.service = {
+      image = "alpine";
       command = [
         "${nft-marketplace-server}/bin/nft-marketplace-server"
         "--db-connection"


### PR DESCRIPTION
Problem: `arion up` running nft-market-server without specific base image, as a consequence, we receive the following error when try to interact with nft.storage:

```
{"error":"Error adding image to DB: Error making an nft.storage client request: ConnectionError (HttpExceptionRequest Request {\n host = \"api.nft.storage\"\n port = 443\n secure = True\n requestHeaders = [(\"Accept\",\"application/json;charset=utf-8,application/json\"),(\"Content-Type\",\"image/png\"),(\"Authorization\",\"<REDACTED>\")]\n path = \"/upload\"\n queryString = \"\"\n method = \"POST\"\n proxy = Nothing\n rawBody = False\n redirectCount = 10\n responseTimeout = ResponseTimeoutDefault\n requestVersion = HTTP/1.1\n}\n (InternalException (HandshakeFailed (Error_Protocol (\"certificate has unknown CA\",True,UnknownCa)))))"}
``` 